### PR TITLE
Remove need for disk-backed temp file, and allow fileless conversion

### DIFF
--- a/ugoira/lib.py
+++ b/ugoira/lib.py
@@ -137,7 +137,6 @@ def convert_apng(
 
     """
 
-
     from apng import APNG, PNG
 
     with open_zip_blob(blob) as zf:
@@ -151,7 +150,7 @@ def convert_apng(
                     delay=int(frames[fname]//speed),
                 )
 
-        return container
+        return container.to_bytes()
 
 
 def make_apng(
@@ -175,8 +174,9 @@ def make_apng(
     """
 
 
-    container = convert_apng(blob, frames, speed)
-    container.save(dest)
+    apng_bytes = convert_apng(blob, frames, speed)
+    with open(dest, "wb") as fp:
+        fp.write(apng_bytes)
 
 
 def make_gif(


### PR DESCRIPTION
Copy of https://github.com/item4/ugoira/pull/6, which got closed by github being annoying about force-pushing

Basically, I have an application where I want to manage my own file saving. 

As such, I've added the ability to convert a ugoira file/metadata combo to a APNG in-memory, returning the bytes the file corresponds to. 

Also, I switched `open_zip_blob()` from using `tempfile()` to `io.BytesIO()`, because why would you use a physical temp file if you don't have to (it's much faster to do it in-memory).

It passes tests locally. 

![image](https://user-images.githubusercontent.com/1401239/65480794-ad1e5000-de47-11e9-9e03-21934815c271.png)
